### PR TITLE
read files by size of the file instead of fixed size

### DIFF
--- a/lib/std/header.ibu
+++ b/lib/std/header.ibu
@@ -3,7 +3,6 @@
 #define STDIN 0
 #define STDIO 1
 #define STDERR 2
-#define PROGRAM_MAX_SIZE 170000
 
 struct Vec {
     ptr **u8,
@@ -15,6 +14,29 @@ struct BlockHeader {
     size i32,
     is_free bool,
     next *BlockHeader,
+}
+
+struct TimeSpec {
+    tv_sec i64,
+    tv_nsec i64,
+}
+
+struct Stat {
+    st_dev u64,
+    st_ino u64,
+    st_nlink u64,
+    st_mode u32,
+    st_uid u32,
+    st_gid u32,
+    pad0 i32,
+    st_rdev u64,
+    st_size i64,
+    st_blksize i64,
+    st_blocks i64,
+    st_atim TimeSpec,
+    st_mtim TimeSpec,
+    st_ctim TimeSpec,
+    unused [3]i64,
 }
 
 func sbrk(increment i32) *u8;
@@ -47,3 +69,4 @@ func printf(fmt *u8, ...) i32;
 func eprintf(fmt *u8, ...) i32;
 func sprintf(buf *u8, fmt *u8, ...) i32;
 func strndup(str *u8, n i32) *u8;
+func fstat(fd i32, buf *Stat) i64;

--- a/lib/std/std.ibu
+++ b/lib/std/std.ibu
@@ -6,6 +6,10 @@
 
 let free_list *u8;
 
+func fstat(fd i32, buf *Stat) i64 {
+    return syscall(SYS_FSTAT, fd, buf, 0);
+}
+
 func memset(ptr *u8, val u8, n i32) u0 {
     for let i i32 = 0; i < n; i++ {
         ptr[i] = val;

--- a/lib/std/std.ibu
+++ b/lib/std/std.ibu
@@ -61,7 +61,7 @@ func alloc(size i32) *u8 {
         return nil;
     }
 
-    let aligned_size i32 = size;
+    let aligned_size i32 = align_to(size, 8);
     let block *BlockHeader = find_free_block(aligned_size);
     if block == nil {
         block = request_space(aligned_size);

--- a/src/ibu.ibu
+++ b/src/ibu.ibu
@@ -25,13 +25,21 @@ func main(argc i32, argv **u8) i32 {
         }
     }
 
-    let program *u8 = alloc(PROGRAM_MAX_SIZE);
+    let stat Stat = {};
+    let fstat_result i64 = fstat(fd, &stat);
+    if fstat_result < 0 {
+        eprintf("error: fstat failed\n");
+        exit(1);
+    }
+
+    let program *u8 = alloc(stat.st_size+1);
     if program == nil {
         eprintf("memory allocation failed\n");
         exit(1);
     }
-    read(fd, program, PROGRAM_MAX_SIZE);
+    read(fd, program, stat.st_size);
     close(fd);
+    program[stat.st_size] = '\0';
 
     let t *Tokenizer = new_tokenizer(file_name, program);
     let tokens *Token = tokenize(t);

--- a/src/preprocessor/preprocessor.ibu
+++ b/src/preprocessor/preprocessor.ibu
@@ -168,12 +168,20 @@ func preprocess(tok *Token, p *Preprocessor) u0 {
             if !already_imported {
                 vec_append(p.included_file_full_path, file_full_path);
 
-                let buf *u8 = alloc(PROGRAM_MAX_SIZE);
+                let stat Stat = {};
+                let fstat_result i64 = fstat(fd, &stat);
+                if fstat_result < 0 {
+                    eprintf("error: fstat failed\n");
+                    exit(1);
+                }
+
+                let buf *u8 = alloc(stat.st_size+1); // FIXME: dont know why +1 but it works
                 if buf == nil {
                     eprintf("memory allocation failed\n");
                     exit(1);
                 }
-                read(fd, buf, PROGRAM_MAX_SIZE);
+                read(fd, buf, stat.st_size);
+                buf[stat.st_size] = '\0';
                 close(fd);
 
                 let tokens *Token = tokenize(new_tokenizer(new_file_name, buf));
@@ -182,6 +190,7 @@ func preprocess(tok *Token, p *Preprocessor) u0 {
                 *get_eof_from_tokens(tokens) = *tok.next.next.next;
                 *tok = *tokens;
             } else {
+                close(fd);
                 *tok = *tok.next.next.next;
             }
         } else {


### PR DESCRIPTION
issue: [use fstat syscall instead of MAX_PROGRAM_SIZE #18](https://github.com/v420v/ibu/issues/18)

Previously, a fixed allocation of 170,000 bytes of memory was used whenever a file was loaded. With this pull request, the memory allocation will now depend on the actual file size.
