### PR TITLE
support nested switch statements (#13)

### DIFF
--- a/src/parser/header.ibu
+++ b/src/parser/header.ibu
@@ -142,6 +142,7 @@ struct Node {
     func_name *u8,
     offset i32,
     args *Vec,
+    outer *Node, // switch statement outer switch node if exists
 }
 
 #define RelocKind i32

--- a/src/parser/parser.ibu
+++ b/src/parser/parser.ibu
@@ -465,16 +465,16 @@ func parse_label(p *Parser) *Node {
 }
 
 func parse_switch(p *Parser) *Node {
-    if p.current_switch != nil {
-        print_error(p.tokens, "nested switch statements are not supported yet");
-    }
-
     let switch_tok *Token = p.tokens;
 
     parser_skip(p, "switch");
     let node *Node = new_node(ND_SWITCH);
 
     node.label_name = new_unique_label();
+
+    if p.current_switch != nil {
+        node.outer = p.current_switch;
+    }
 
     p.current_switch = node;
 
@@ -488,7 +488,7 @@ func parse_switch(p *Parser) *Node {
         print_error(switch_tok, "switch statement must have at least one case");
     }
 
-    p.current_switch = nil;
+    p.current_switch = node.outer;
 
     return node;
 }


### PR DESCRIPTION
```
func main() i32 {
    let a i32 = 3;
    switch a {
        case 1:
            return 1;
        case 2:
            return 2;
        case 3:
            switch a + 1 {
                case 1:
                    return 10 + 1;
                case 2:
                    return 10 + 2;
                case 3:
                    return 10 + 3;
                case 4:
                    return 10 + 4;
                case 5:
                    return 10 + 5;
            }
        case 4:
            return 4;
    }
    return 0;
}
```
<img width="432" height="111" alt="Screenshot 2025-07-24 at 3 16 53" src="https://github.com/user-attachments/assets/4c0138be-f6d7-4490-a55e-f2454adc636b" />
